### PR TITLE
Fixed receiveArray function and its declaration

### DIFF
--- a/ManchesterRF.cpp
+++ b/ManchesterRF.cpp
@@ -929,10 +929,10 @@ uint8_t ManchesterRF::transmitArray(uint8_t size, uint8_t *data) {
 }//end of send the data
 
 
-uint8_t ManchesterRF::receiveArray(uint8_t &size, uint8_t *data) {
+uint8_t ManchesterRF::receiveArray(uint8_t &size, uint8_t **data) {
   if (MAN_IS_BUFF_EMPTY) return 0;
   size = man_rx_buff[man_rx_buff_start][0];
-  data = &man_rx_buff[man_rx_buff_start][1];
+  *data = &man_rx_buff[man_rx_buff_start][1];
   man_rx_buff_start = (man_rx_buff_start + 1) % MAN_BUF_SIZE; //remove message from the buffer
   return 1;
 }

--- a/ManchesterRF.h
+++ b/ManchesterRF.h
@@ -130,7 +130,7 @@ class ManchesterRF : public Stream {
 //    uint8_t available();
 
     uint8_t transmitArray(uint8_t size, uint8_t *data); // transmit array of bytes
-    uint8_t receiveArray(uint8_t &size, uint8_t *data); // receive array of bytes
+    uint8_t receiveArray(uint8_t &size, uint8_t **data); // receive array of bytes
     
     uint8_t transmitPacket(uint8_t size, uint8_t from, uint8_t to, uint8_t meta, uint8_t *payload); //decode receive buffer into a packet, return 1 if valid packet received, otherwise 0
     uint8_t receivePacket(uint8_t &size, uint8_t &from, uint8_t &to, uint8_t &meta, uint8_t **payload); //decode receive buffer into a packet, return 1 if valid packet received, otherwise 0

--- a/examples/ManchesterRX_Array/ManchesterRX_Array.ino
+++ b/examples/ManchesterRX_Array/ManchesterRX_Array.ino
@@ -28,7 +28,7 @@ void setup() {
 void loop() {
 
   if (rf.available()) { //something is in RX buffer
-    if (rf.receiveArray(size, data)) {
+    if (rf.receiveArray(size, &data)) {
       //process the data
       for (int i = 0; i < size; i++) {
          data[i]; //do something with the data 


### PR DESCRIPTION
Now it points to the right place of received data in buffer.
Fixed an example with receiveArray.

Before this change I was getting always the same random data regardless what was sent in array. I looked at receivePacket function and tried to declare `data` as the `payload` parameter. It worked out!